### PR TITLE
fix: ensure act compatibility for reusable workflows

### DIFF
--- a/.github/workflows/golang-binary-release.yaml
+++ b/.github/workflows/golang-binary-release.yaml
@@ -44,23 +44,36 @@ jobs:
           '
 
       - uses: actions/checkout@v4
-
-      - name: Install Act dependencies
+      - name: Checkout shared actions for act
         if: ${{ env.ACT }}
-        uses: ./.github/actions/setup-act-env
-
-      - name: Checkout shared actions
         uses: actions/checkout@v4
         with:
           repository: spigell/my-shared-workflows
           path: .github/actions-temp
 
-      - name: Move actions into correct path
+      - name: Move actions into workspace
+        if: ${{ env.ACT }}
         run: |
           rsync -a .github/actions-temp/.github/actions/ .github/actions/
 
+      - name: Install Act dependencies
+        if: ${{ env.ACT }}
+        uses: ./.github/actions/setup-act-env
+
+      - name: Get shared actions
+        if: ${{ !env.ACT }}
+        run: |
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
+
       - name: Setup Go and install deps
+        if: ${{ env.ACT }}
         uses: ./.github/actions/setup-go-env
+        with:
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Setup Go and install deps
+        if: ${{ !env.ACT }}
+        uses: ./../actions/.github/actions/setup-go-env
         with:
           working-directory: ${{ inputs.working-directory }}
 

--- a/.github/workflows/golang-binary-release.yaml
+++ b/.github/workflows/golang-binary-release.yaml
@@ -44,26 +44,13 @@ jobs:
           '
 
       - uses: actions/checkout@v4
-      - name: Checkout shared actions for act
-        if: ${{ env.ACT }}
-        uses: actions/checkout@v4
-        with:
-          repository: spigell/my-shared-workflows
-          path: .github/actions-temp
-
-      - name: Move actions into workspace
-        if: ${{ env.ACT }}
+      - name: Get actions
         run: |
-          rsync -a .github/actions-temp/.github/actions/ .github/actions/
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Install Act dependencies
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
-
-      - name: Get shared actions
-        if: ${{ !env.ACT }}
-        run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Setup Go and install deps
         if: ${{ env.ACT }}
@@ -71,6 +58,8 @@ jobs:
         with:
           working-directory: ${{ inputs.working-directory }}
 
+      # https://github.com/nektos/act/pull/2108
+      # We can not use ACT with actions outside of workspace
       - name: Setup Go and install deps
         if: ${{ !env.ACT }}
         uses: ./../actions/.github/actions/setup-go-env

--- a/.github/workflows/golang-binary-release.yaml
+++ b/.github/workflows/golang-binary-release.yaml
@@ -49,12 +49,18 @@ jobs:
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
 
-      - name: Get actions
+      - name: Checkout shared actions
+        uses: actions/checkout@v4
+        with:
+          repository: spigell/my-shared-workflows
+          path: .github/actions-temp
+
+      - name: Move actions into correct path
         run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
+          rsync -a .github/actions-temp/.github/actions/ .github/actions/
 
       - name: Setup Go and install deps
-        uses: ./../actions/.github/actions/setup-go-env
+        uses: ./.github/actions/setup-go-env
         with:
           working-directory: ${{ inputs.working-directory }}
 

--- a/.github/workflows/golang-pulumi-test-lint.yaml
+++ b/.github/workflows/golang-pulumi-test-lint.yaml
@@ -24,26 +24,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get actions
-        run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
-
       - name: Install Act dependencies
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
 
-      - name: Setup Go and install deps
-        if: ${{ env.ACT }}
-        uses: ./.github/actions/setup-pulumi-env
+      - name: Checkout shared actions
+        uses: actions/checkout@v4
         with:
-          runtime: go
-          working-directory: ${{ inputs.working-directory }}
+          repository: spigell/my-shared-workflows
+          path: .github/actions-temp
 
-      # https://github.com/nektos/act/pull/2108
-      # We can not use ACT with actions outside of workspace
+      - name: Move actions into correct path
+        run: |
+          rsync -a .github/actions-temp/.github/actions/ .github/actions/
+
       - name: Setup Go and install deps
-        if: ${{ !env.ACT }}
-        uses: ./../actions/.github/actions/setup-pulumi-env
+        uses: ./.github/actions/setup-pulumi-env
         with:
           runtime: go
           working-directory: ${{ inputs.working-directory }}
@@ -65,20 +61,17 @@ jobs:
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
 
-      - name: Get actions
-        if: ${{ !env.ACT }}
-        run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
-
-      - name: Setup Go and install deps
-        if: ${{ !env.ACT }}
-        uses: ./../actions/.github/actions/setup-pulumi-env
+      - name: Checkout shared actions
+        uses: actions/checkout@v4
         with:
-          runtime: go
-          working-directory: ${{ inputs.working-directory }}
+          repository: spigell/my-shared-workflows
+          path: .github/actions-temp
+
+      - name: Move actions into correct path
+        run: |
+          rsync -a .github/actions-temp/.github/actions/ .github/actions/
 
       - name: Setup Go and install deps
-        if: ${{ env.ACT }}
         uses: ./.github/actions/setup-pulumi-env
         with:
           runtime: go

--- a/.github/workflows/golang-pulumi-test-lint.yaml
+++ b/.github/workflows/golang-pulumi-test-lint.yaml
@@ -23,23 +23,37 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Act dependencies
+      - name: Checkout shared actions for act
         if: ${{ env.ACT }}
-        uses: ./.github/actions/setup-act-env
-
-      - name: Checkout shared actions
         uses: actions/checkout@v4
         with:
           repository: spigell/my-shared-workflows
           path: .github/actions-temp
 
-      - name: Move actions into correct path
+      - name: Move actions into workspace
+        if: ${{ env.ACT }}
         run: |
           rsync -a .github/actions-temp/.github/actions/ .github/actions/
 
+      - name: Install Act dependencies
+        if: ${{ env.ACT }}
+        uses: ./.github/actions/setup-act-env
+
+      - name: Get shared actions
+        if: ${{ !env.ACT }}
+        run: |
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
+
       - name: Setup Go and install deps
+        if: ${{ env.ACT }}
         uses: ./.github/actions/setup-pulumi-env
+        with:
+          runtime: go
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Setup Go and install deps
+        if: ${{ !env.ACT }}
+        uses: ./../actions/.github/actions/setup-pulumi-env
         with:
           runtime: go
           working-directory: ${{ inputs.working-directory }}
@@ -56,23 +70,37 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Act dependencies
+      - name: Checkout shared actions for act
         if: ${{ env.ACT }}
-        uses: ./.github/actions/setup-act-env
-
-      - name: Checkout shared actions
         uses: actions/checkout@v4
         with:
           repository: spigell/my-shared-workflows
           path: .github/actions-temp
 
-      - name: Move actions into correct path
+      - name: Move actions into workspace
+        if: ${{ env.ACT }}
         run: |
           rsync -a .github/actions-temp/.github/actions/ .github/actions/
 
+      - name: Install Act dependencies
+        if: ${{ env.ACT }}
+        uses: ./.github/actions/setup-act-env
+
+      - name: Get shared actions
+        if: ${{ !env.ACT }}
+        run: |
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
+
       - name: Setup Go and install deps
+        if: ${{ env.ACT }}
         uses: ./.github/actions/setup-pulumi-env
+        with:
+          runtime: go
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Setup Go and install deps
+        if: ${{ !env.ACT }}
+        uses: ./../actions/.github/actions/setup-pulumi-env
         with:
           runtime: go
           working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/golang-pulumi-test-lint.yaml
+++ b/.github/workflows/golang-pulumi-test-lint.yaml
@@ -23,26 +23,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout shared actions for act
-        if: ${{ env.ACT }}
-        uses: actions/checkout@v4
-        with:
-          repository: spigell/my-shared-workflows
-          path: .github/actions-temp
-
-      - name: Move actions into workspace
-        if: ${{ env.ACT }}
+      - name: Get actions
         run: |
-          rsync -a .github/actions-temp/.github/actions/ .github/actions/
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Install Act dependencies
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
-
-      - name: Get shared actions
-        if: ${{ !env.ACT }}
-        run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Setup Go and install deps
         if: ${{ env.ACT }}
@@ -51,6 +38,8 @@ jobs:
           runtime: go
           working-directory: ${{ inputs.working-directory }}
 
+      # https://github.com/nektos/act/pull/2108
+      # We can not use ACT with actions outside of workspace
       - name: Setup Go and install deps
         if: ${{ !env.ACT }}
         uses: ./../actions/.github/actions/setup-pulumi-env
@@ -70,26 +59,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout shared actions for act
-        if: ${{ env.ACT }}
-        uses: actions/checkout@v4
-        with:
-          repository: spigell/my-shared-workflows
-          path: .github/actions-temp
-
-      - name: Move actions into workspace
-        if: ${{ env.ACT }}
+      - name: Get actions
         run: |
-          rsync -a .github/actions-temp/.github/actions/ .github/actions/
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Install Act dependencies
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
-
-      - name: Get shared actions
-        if: ${{ !env.ACT }}
-        run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Setup Go and install deps
         if: ${{ env.ACT }}
@@ -98,6 +74,8 @@ jobs:
           runtime: go
           working-directory: ${{ inputs.working-directory }}
 
+      # https://github.com/nektos/act/pull/2108
+      # We can not use ACT with actions outside of workspace
       - name: Setup Go and install deps
         if: ${{ !env.ACT }}
         uses: ./../actions/.github/actions/setup-pulumi-env

--- a/.github/workflows/golang-test-lint.yaml
+++ b/.github/workflows/golang-test-lint.yaml
@@ -57,16 +57,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get actions
-        run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
-
       - name: Install Act dependencies
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
 
+      - name: Checkout shared actions
+        uses: actions/checkout@v4
+        with:
+          repository: spigell/my-shared-workflows
+          path: .github/actions-temp
+
+      - name: Move actions into correct path
+        run: |
+          rsync -a .github/actions-temp/.github/actions/ .github/actions/
+
       - name: Setup Go and install deps
-        uses: ./../actions/.github/actions/setup-go-env
+        uses: ./.github/actions/setup-go-env
         with:
           working-directory: ${{ inputs.working-directory }}
 

--- a/.github/workflows/golang-test-lint.yaml
+++ b/.github/workflows/golang-test-lint.yaml
@@ -23,23 +23,37 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Act dependencies
+      - name: Checkout shared actions for act
         if: ${{ env.ACT }}
-        uses: ./.github/actions/setup-act-env
-
-      - name: Checkout shared actions
         uses: actions/checkout@v4
         with:
           repository: spigell/my-shared-workflows
           path: .github/actions-temp
 
-      - name: Move actions into correct path
+      - name: Move actions into workspace
+        if: ${{ env.ACT }}
         run: |
           rsync -a .github/actions-temp/.github/actions/ .github/actions/
 
+      - name: Install Act dependencies
+        if: ${{ env.ACT }}
+        uses: ./.github/actions/setup-act-env
+
+      - name: Get shared actions
+        if: ${{ !env.ACT }}
+        run: |
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
+
       - name: Setup Go and install deps
+        if: ${{ env.ACT }}
         uses: ./.github/actions/setup-go-env
+        with:
+          go-version: ${{ inputs.go-version }}
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Setup Go and install deps
+        if: ${{ !env.ACT }}
+        uses: ./../actions/.github/actions/setup-go-env
         with:
           go-version: ${{ inputs.go-version }}
           working-directory: ${{ inputs.working-directory }}
@@ -56,23 +70,36 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Act dependencies
+      - name: Checkout shared actions for act
         if: ${{ env.ACT }}
-        uses: ./.github/actions/setup-act-env
-
-      - name: Checkout shared actions
         uses: actions/checkout@v4
         with:
           repository: spigell/my-shared-workflows
           path: .github/actions-temp
 
-      - name: Move actions into correct path
+      - name: Move actions into workspace
+        if: ${{ env.ACT }}
         run: |
           rsync -a .github/actions-temp/.github/actions/ .github/actions/
 
+      - name: Install Act dependencies
+        if: ${{ env.ACT }}
+        uses: ./.github/actions/setup-act-env
+
+      - name: Get shared actions
+        if: ${{ !env.ACT }}
+        run: |
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
+
       - name: Setup Go and install deps
+        if: ${{ env.ACT }}
         uses: ./.github/actions/setup-go-env
+        with:
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Setup Go and install deps
+        if: ${{ !env.ACT }}
+        uses: ./../actions/.github/actions/setup-go-env
         with:
           working-directory: ${{ inputs.working-directory }}
 

--- a/.github/workflows/golang-test-lint.yaml
+++ b/.github/workflows/golang-test-lint.yaml
@@ -23,26 +23,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout shared actions for act
-        if: ${{ env.ACT }}
-        uses: actions/checkout@v4
-        with:
-          repository: spigell/my-shared-workflows
-          path: .github/actions-temp
-
-      - name: Move actions into workspace
-        if: ${{ env.ACT }}
+      - name: Get actions
         run: |
-          rsync -a .github/actions-temp/.github/actions/ .github/actions/
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Install Act dependencies
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
-
-      - name: Get shared actions
-        if: ${{ !env.ACT }}
-        run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Setup Go and install deps
         if: ${{ env.ACT }}
@@ -51,6 +38,8 @@ jobs:
           go-version: ${{ inputs.go-version }}
           working-directory: ${{ inputs.working-directory }}
 
+      # https://github.com/nektos/act/pull/2108
+      # We can not use ACT with actions outside of workspace
       - name: Setup Go and install deps
         if: ${{ !env.ACT }}
         uses: ./../actions/.github/actions/setup-go-env
@@ -70,26 +59,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout shared actions for act
-        if: ${{ env.ACT }}
-        uses: actions/checkout@v4
-        with:
-          repository: spigell/my-shared-workflows
-          path: .github/actions-temp
-
-      - name: Move actions into workspace
-        if: ${{ env.ACT }}
+      - name: Get actions
         run: |
-          rsync -a .github/actions-temp/.github/actions/ .github/actions/
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Install Act dependencies
         if: ${{ env.ACT }}
         uses: ./.github/actions/setup-act-env
-
-      - name: Get shared actions
-        if: ${{ !env.ACT }}
-        run: |
-          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ../actions
 
       - name: Setup Go and install deps
         if: ${{ env.ACT }}
@@ -97,6 +73,8 @@ jobs:
         with:
           working-directory: ${{ inputs.working-directory }}
 
+      # https://github.com/nektos/act/pull/2108
+      # We can not use ACT with actions outside of workspace
       - name: Setup Go and install deps
         if: ${{ !env.ACT }}
         uses: ./../actions/.github/actions/setup-go-env


### PR DESCRIPTION
## Summary
- check out shared actions into workspace for all reusable workflows
- update linter job in `golang-test-lint` to use workspace actions
- apply same act workaround to pulumi and binary release workflows

## Testing
- `act --dryrun -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 -W .github/workflows/golang-test-lint-call.yaml` *(fails: Cannot connect to the Docker daemon)*
- `act --dryrun -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 -W .github/workflows/golang-pulumi-test-lint-call.yaml` *(fails: Cannot connect to the Docker daemon)*
- `act --dryrun -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 -W .github/workflows/golang-binary-release-call.yaml` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a94285b84c832f81e3b2cfccdf8859