### PR TITLE
Add NodeJS package release workflow

### DIFF
--- a/.github/workflows/npm-package-release.yaml
+++ b/.github/workflows/npm-package-release.yaml
@@ -1,0 +1,110 @@
+name: The NPM package uploading
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+      setup-action:
+        required: false
+        type: string
+        default: 'setup-node-env'
+      platform:
+        required: false
+        type: string
+        default: 'npm'
+    secrets:
+      gh-token:
+        required: true
+
+jobs:
+  release:
+    name: "Release NodeJS package"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate ref
+        if: ${{ !env.ACT }}
+        env:
+          GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITHUB_EVENT_BASE_REF: ${{ github.event.base_ref }}
+        run: |
+          node -e '
+            const ref = process.env.GITHUB_REF;
+            console.log("Current ref:", ref);
+
+            const baseRef = process.env.GITHUB_EVENT_BASE_REF;
+            const defaultBranch = process.env.GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH;
+
+            const isDefaultBranch = baseRef === `refs/heads/${defaultBranch}`;
+            if (!isDefaultBranch) {
+              console.log(`Not Valid: must be running on default branch (${defaultBranch})`);
+              process.exit(1);
+            }
+
+            const isTag = ref.startsWith("refs/tags/");
+            if (!isTag) {
+              console.log(`Not Valid: must be running on tag (${ref})`);
+              process.exit(1);
+            }
+
+            console.log("✅ Valid ref:", ref);
+          '
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Get actions
+        if: ${{ !env.ACT }}
+        run: |
+          git clone "$GITHUB_SERVER_URL/spigell/my-shared-workflows" ./.github/actions_ext
+
+      - name: Install Act dependencies
+        if: ${{ env.ACT }}
+        uses: ./.github/actions/setup-act-env
+
+      - name: Ignore external actions folder
+        run: |
+          echo ".github/actions_ext" >> .git/info/exclude
+          git status --porcelain
+
+      - name: Setup Node env
+        if: ${{ inputs.setup-action == 'setup-node-env' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Go env
+        if: ${{ inputs.setup-action == 'setup-go-env' }}
+        uses: ./.github/actions_ext/.github/actions/setup-go-env
+        with:
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Setup Pulumi env
+        if: ${{ inputs.setup-action == 'setup-pulumi-env' }}
+        uses: ./.github/actions_ext/.github/actions/setup-pulumi-env
+        with:
+          runtime: nodejs
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Build package
+        run: npm pack
+        working-directory: ${{ inputs.working-directory }}
+
+      - name: Publish package to npm
+        if: ${{ inputs.platform == 'npm' }}
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          package: ${{ inputs.working-directory }}
+          token: ${{ secrets.gh-token }}
+          dry-run: false
+
+      - name: Publish package to GitHub Packages
+        if: ${{ inputs.platform == 'github' }}
+        run: |
+          npm config set '//npm.pkg.github.com/:_authToken' '${{ secrets.gh-token }}'
+          npm publish --registry https://npm.pkg.github.com
+        working-directory: ${{ inputs.working-directory }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shared GitHub Workflows
 
-Reusable GitHub Actions workflows and composite actions for Go (Golang) and TypeScript projects.
+Reusable GitHub Actions workflows and composite actions for Go (Golang) and NodeJS/TypeScript projects.
 
 ## 📁 Structure
 ```
@@ -22,6 +22,13 @@ jobs:
     with:
       go-version: '1.22'
       working-directory: '.'
+  release:
+    uses: your-org/shared-workflows/.github/workflows/npm-package-release.yaml@main
+    with:
+      working-directory: '.'
+      platform: npm
+    secrets:
+      gh-token: ${{ secrets.NPM_TOKEN }}
 ```
 
 🧪 Local Testing

--- a/testdata/nodejs/Makefile
+++ b/testdata/nodejs/Makefile
@@ -1,0 +1,11 @@
+.RECIPEPREFIX = >
+.PHONY: generate_schema install_nodejs_sdk build_nodejs_sdk
+
+generate_schema:
+> @echo "Generating schema"
+
+install_nodejs_sdk:
+> @echo "Installing NodeJS SDK"
+
+build_nodejs_sdk:
+> npm pack

--- a/testdata/nodejs/index.js
+++ b/testdata/nodejs/index.js
@@ -1,0 +1,3 @@
+export default function () {
+  console.log('Hello from test package');
+}

--- a/testdata/nodejs/package.json
+++ b/testdata/nodejs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@example/testdata-node",
+  "version": "1.0.0",
+  "description": "Test NodeJS package for shared workflows",
+  "type": "module",
+  "exports": "./index.js",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add reusable npm package release workflow supporting npm and GitHub registries
- document and test new workflow with sample node project using ES modules

## Testing
- `npm pack`
- `node -e "import('./testdata/nodejs/index.js').then(m => m.default())"`


------
https://chatgpt.com/codex/tasks/task_e_68b53bd6f0e4832f8429e5fda560ed7c