### PR TITLE
Add build context input to Docker release workflow

### DIFF
--- a/.github/workflows/docker-build-release-call.yaml
+++ b/.github/workflows/docker-build-release-call.yaml
@@ -14,3 +14,15 @@ jobs:
       build-args: |
         GO_VERSION=1.25
 
+  build-context-release:
+    uses: ./.github/workflows/docker-build-release.yaml
+    with:
+      image-name: golang-test-relase
+      dry-run: true
+      context: ./testdata/golang
+      version: v0.1.0
+      build-args: |
+        GO_VERSION=1.25
+      build-contexts: |
+        deps=./testdata/golang/vendor
+

--- a/.github/workflows/docker-build-release-call.yaml
+++ b/.github/workflows/docker-build-release-call.yaml
@@ -24,5 +24,5 @@ jobs:
       build-args: |
         GO_VERSION=1.25
       build-contexts: |
-        shared=../shared
+        shared=./testdata/shared
 

--- a/.github/workflows/docker-build-release-call.yaml
+++ b/.github/workflows/docker-build-release-call.yaml
@@ -24,5 +24,5 @@ jobs:
       build-args: |
         GO_VERSION=1.25
       build-contexts: |
-        deps=./testdata/golang/vendor
+        shared=../shared
 

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -16,6 +16,10 @@ on:
       build-args:
         required: false
         type: string
+      build-contexts:
+        required: false
+        type: string
+        default: ""
       dry-run:
         required: false
         type: boolean
@@ -66,3 +70,4 @@ jobs:
             ghcr.io/${{ github.actor }}/${{ inputs.image-name }}:${{ inputs.version }}-${{ steps.short-sha.outputs.sha }}
             ghcr.io/${{ github.actor }}/${{ inputs.image-name }}:${{ inputs.version }}-latest
           build-args: ${{ inputs.build-args }}
+          build-contexts: ${{ inputs.build-contexts }}

--- a/testdata/golang/Dockerfile
+++ b/testdata/golang/Dockerfile
@@ -20,6 +20,7 @@ FROM alpine:3.19
 WORKDIR /app
 
 COPY --from=builder /app/server .
+COPY --from=shared shared-script.sh /shared-script.sh
 
 EXPOSE 8080
 

--- a/testdata/golang/Dockerfile
+++ b/testdata/golang/Dockerfile
@@ -20,7 +20,6 @@ FROM alpine:3.19
 WORKDIR /app
 
 COPY --from=builder /app/server .
-COPY --from=shared shared-script.sh /shared-script.sh
 
 EXPOSE 8080
 

--- a/testdata/shared/shared-script.sh
+++ b/testdata/shared/shared-script.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'Hello world'


### PR DESCRIPTION
## Summary
- add optional build-contexts input to the reusable Docker build workflow
- forward the optional build contexts to docker/build-push-action and document usage in the call example
- add a dedicated example job that exercises the new build-contexts input without changing the original basic release example

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef5e20e168832f899b84150a202771