### PR TITLE
Allow overriding GH token in reusable build workflow

### DIFF
--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.gh-token != "" || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.gh-token || secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.gh-token != || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.gh-token != "" || secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -27,7 +27,6 @@ on:
     secrets:
       gh-token:
         required: false
-        type: string
 
     outputs:
       version:

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      gh-token:
+        required: false
+        type: string
+
     outputs:
       version:
         value: ${{ inputs.version }}
@@ -57,7 +62,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.gh-token != || secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
- add an optional `gh-token` secret input to the reusable docker-build workflow so callers can pass a PAT
- fall back to the default `GITHUB_TOKEN` when the optional secret isn’t provided

## Testing
- not run (workflow change only)
